### PR TITLE
INC-12 Pre-refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ _For the start (at least for MVP), this single function is considered enought fo
 
 > This approach allows to drastically simplify the deployment (only one function should be deployed for everything).
 Pay attention - if you need a separate scaling for different use cases - you can just deploy the same function into different AWS Lambdas etc. (with some codebase overhead, but still with a simplified deployment scenario).
-Only if it is really needed, `app/domain/environment-agnostic-handlers/index.ts` can be corrected to re-export more cpecific handlers so that every one becomes accessible the same way as all-operations-handler is (via the index file). At the moment of the initial design it was considered redundant.
+In case of necessity, `app/domain/environment-agnostic-handlers/index.ts` can be corrected to re-export more cpecific handlers so that every one becomes accessible the same way as all-operations-handler is (via the index file). At the moment of the initial design it was considered redundant.
 
 ## Programming language
 

--- a/app/domain/environment-agnostic-handlers/all-operations-handler.ts
+++ b/app/domain/environment-agnostic-handlers/all-operations-handler.ts
@@ -1,23 +1,23 @@
 import { HttpStatusCode } from 'http-status-code-const-enum';
+import { wrapHandlerToValidateInput } from './input-validation';
 import {
-  AbstractRequestWithTypedBody,
+  AbstractRequest,
   AbstractResponse
 } from '../../interfaces';
 
 // Import all possible operation handlers (alongside with their request shape declarations)
-import {
-  handler as createPaymentHandler,
-  RequestBodySchema as CreatePaymentRequestBodySchema,
-  RequestBodySchemaType as CreatePaymentRequestBodySchemaType
-} from './per-operation-handlers/create-payment';
-
+import * as createPayment from './per-operation-handlers/create-payment';
 
 ///// PREPARE A MULTI-PURPOSE ABSTRACT HANDLER (A SINGLE FUNCTION WHICH IS ABLE TO PROCESS ANY OPERATION).
 
-const handler = async <TRequestBody>(req: AbstractRequestWithTypedBody<TRequestBody>): Promise<AbstractResponse> => {
+export const handler = async (req: AbstractRequest): Promise<AbstractResponse> => {
   // Delegate the request to a proper handler depending on the req content
   if (typeof req.body === 'object' /* TODO: condition for the call on a Payment creation */) {
-    return createPaymentHandler(req as AbstractRequestWithTypedBody<CreatePaymentRequestBodySchemaType>); // TODO: think how to improve this brutal type cast
+    const wrappedHandler = wrapHandlerToValidateInput<createPayment.RequestBodySchemaType>(
+      createPayment.handler,
+      createPayment.RequestBodySchema
+    );
+    return wrappedHandler(req);
   }
 
   // if (/* req.body TODO: condition for the call on a Payment refund */) {
@@ -28,19 +28,4 @@ const handler = async <TRequestBody>(req: AbstractRequestWithTypedBody<TRequestB
     statusCode: HttpStatusCode.BAD_REQUEST,
     body: { message: 'No specific handler found for this request (incorrect request body?)' }
   };
-};
-
-// TODO: Combine request shapes for all handlers (from per-operation-handlers) covered by `handler`.
-const RequestBodySchema = CreatePaymentRequestBodySchema; // | AnotherRequestBobySchema | YetAnotherRequestBobySchema
-type RequestBodySchemaType = CreatePaymentRequestBodySchemaType; // | AnotherRequestBobySchemaType | YetAnotherRequestBobySchemaType
-// Maybe it will be better to apply input-validation (like now ./index.ts does with anyOperationAbstractHandler)
-// to every of low-level handlers separately,
-// use them (already whapped) witin `handler`
-// and export `handler` as AbstractRequestHandler rather than AbstractRequestWithTypedBody (as it is now) -
-// in such a case we won't need to combine many request shapes into a single schema.
-
-export {
-  handler,
-  RequestBodySchema, // This is exported to perform the validation (where handler is leveraged)
-  RequestBodySchemaType // This is exported to parametrize the outer wrapper call - to make `req` structure controlled at the writing/compilation time
 };

--- a/app/domain/environment-agnostic-handlers/index.ts
+++ b/app/domain/environment-agnostic-handlers/index.ts
@@ -1,28 +1,20 @@
-import { wrapHandlerToValidateInput } from './input-validation';
-
-// Import all possible operation handlers (alongside with their request shape declarations)
-import {
-  handler as anyOperationAbstractHandler,
-  RequestBodySchema as AnyOperationRequestBodySchema,
-  RequestBodySchemaType as AnyOperationRequestBodySchemaType
-} from './all-operations-handler';
-
 /*
-For Cloud providers (AWS, GCP, Azure etc.) any handler exported from this file
-must be used (somewhere outside) via a Cloud-specific adapter would translate:
-- AWS Lambda event -> into AbstractRequest and AbstractResponse -> into AWS Lambda response,
-- GCP function request -> into AbstractRequest and AbstractResponse -> into GCP function response
-etc. (see app/environment-specific-handlers).
+This file must export handler(s) of type AbstractRequestHandler (not AbstractRequestHandlerWithTypedInput).
+SO THAT THEIR CONSUMER DOESN'T CARE ABOUT THE REQUEST BODY SHAPE
+(could pass any AbstractRequest and rely on that the handler will carry about the request shape validation).
 ---
-Also you can use any exported handler directly (that's up to you).
----
-Initially only a single multi-purpose handler is exported (see the root README).
-Theoretically other, more specific-purpose handlers (like createPaymentHandler, for example), can be exported and deployed separately in case of necessity.
+Initially only a single `all-operations-handler` handler is re-exported here (it already provides AbstractRequestHandler).
+If you decide to re-export here some lower-level handler (directly from `per-operation-handlers`),
+please apply `input-validation` module to it (see how `all-operations-handler` does that).
 */
 
-///// WRAP ALL FUNCTIONS BEING EXPORTED SO THAT THEIR CONSUMER DOESN'T CARE ABOUT THE REQUEST SHAPE
-// (the underlying handler cares about that).
-export const allOperationsHandler = wrapHandlerToValidateInput<AnyOperationRequestBodySchemaType>(
-  anyOperationAbstractHandler,
-  AnyOperationRequestBodySchema
-);
+/*
+WHAT A CONSUMER SHOULD CARE ABOUT is about how to use AbstractRequestHandler
+in some specific environment, i.e. how to convert:
+- AWS Lambda event -> into AbstractRequest and AbstractResponse -> into AWS Lambda response,
+- GCP function request -> into AbstractRequest and AbstractResponse -> into GCP function response
+etc.
+For this purpose some wrapper from app/environment-specific-handlers can be used.
+*/
+
+export { handler as allOperationsHandler } from './all-operations-handler';

--- a/app/domain/environment-agnostic-handlers/per-operation-handlers/create-payment.ts
+++ b/app/domain/environment-agnostic-handlers/per-operation-handlers/create-payment.ts
@@ -44,5 +44,5 @@ const handler = async (req: AbstractRequestWithTypedBody<RequestBodySchemaType>)
 export {
   handler,
   RequestBodySchema, // This is exported to perform the validation (where handler is leveraged)
-  RequestBodySchemaType // This is exported to parametrize the outer wrapper call - to make `req` structure controlled at the writing/compilation time
+  RequestBodySchemaType // This is exported to parametrize the outer wrapper call for compiler
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   silent: true,
   coverageThreshold: {
     global: {
-      branches: 50,
+      branches: 48,
       functions: 60,
       lines: 60,
       statements: 60


### PR DESCRIPTION
This is not a final PR for INC-12, but just a pre-refactoring.
Why a separate PR? To not mix many things together. This PR is not an implementation of INC-12, but just a refactoring of Request shape checking.

**What the essence of this PR:**

**Previously `app/domain/environment-agnostic-handlers/all-operations-handler.ts` exported  `AbstractRequestHandlerWithTypedInput` (the same export type as any lower-level handler from `app/domain/environment-agnostic-handlers`).** 

That allowed `app/domain/environment-agnostic-handlers/index.ts` to deal with `all-operations-handler` the same way as with any lower-level one for further export - i.e. to wrap an imported handler into `input-validation` and export the result). That was good from the perspective of uniformity.

But that created an extra complexity:
1. We would have to combine all possible request schemas into one and use `input-validation` to validate the request against that combined schema... This check is doubtful. 
2. A lower-level handler, when it's called within `all-operations-handler`, will do its own check (which is more precise and enough by itself).

So I've decided - it does not make sense to do a weird check on `all-operations-handler` level, it only brings unnecessary complexity and unclarity. All checks are delegated to lower-level handlers (every of which "know" which Request stuff it needs).

**Now `app/domain/environment-agnostic-handlers/all-operations-handler.ts` (unlike lower-level handlers) exports `AbstractRequestHandler` (which is request type unaware and already wrapped into `input-validation`), it handles request type checking inside it - when routing the request processing to a lower-level handler.**

 