### PR TITLE
INC-3 addition: Mock config-service globally

### DIFF
--- a/app/domain/environment-agnostic-handlers/per-operation-handlers/create-payment/request-validation.spec.ts
+++ b/app/domain/environment-agnostic-handlers/per-operation-handlers/create-payment/request-validation.spec.ts
@@ -2,15 +2,7 @@ import handler  from '.';
 import { AbstractRequestWithTypedBody } from '../../../../interfaces';
 import { RequestBodySchemaType } from './request-schema';
 
-jest.mock('../../../services/config-service/index', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  getConfig: () => ({}),
-}));
-
 describe('createPayment handler', () => {
-  afterAll(() => {
-    jest.resetModules();
-  });
 
   const requiredCustomFields = () => {
     return {

--- a/app/domain/services/config-service/config-validation.spec.ts
+++ b/app/domain/services/config-service/config-validation.spec.ts
@@ -1,6 +1,9 @@
 import { ConnectorEnvironment } from './interfaces';
 import { ICommerceToolsConfig } from './schema';
 
+// 'config' module is globally mocked in the test environment - so to test its internals we need to unmock it
+jest.unmock('./index');
+
 describe('Connector config validations', () => {
   const {
     CT_CLIENT_ID,

--- a/app/environment-specific-handlers/aws-http/all-operations-handler.adapted.spec.ts
+++ b/app/environment-specific-handlers/aws-http/all-operations-handler.adapted.spec.ts
@@ -1,20 +1,12 @@
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import { allOperationsHandler as allOperationsApiGatewayHandler } from './index';
 
-jest.mock('../../domain/services/config-service/index', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  getConfig: () => ({}),
-}));
-
 describe('allOperationsHandler as an AWS Lambda function behind AWS API Gateway', () => {
 
   const context: Context = {
     functionName: 'allOperationsHandler'
   } as Context;
 
-  afterAll(() => {
-    jest.resetModules();
-  });
 
   // TODO: All schema-related tests are on the lowest level (in app/domain/environment-agnostic-handlers/per-operation-handlers).
   // On a higher level (here) - test only what is implemented here (mocking a lower-level handler)

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,8 @@ module.exports = {
   ],
   rootDir: '.',
   setupFilesAfterEnv: [
-    '<rootDir>/test/setup/global-hooks.ts'
+    '<rootDir>/test/setup/global-hooks.ts',
+    '<rootDir>/test/setup/load-global-mocks.ts'
   ],
   silent: true,
   coverageThreshold: {

--- a/test/__mocks__/domain/services/config-service/index.ts
+++ b/test/__mocks__/domain/services/config-service/index.ts
@@ -1,0 +1,14 @@
+export default {
+  getConfig: jest.fn().mockImplementation(() => {
+    return {
+      clientId: 'Test clientId',
+      clientSercet: 'Test clientSercet',
+      projectId: 'Test projectId',
+      authUrl: 'Test authUrl',
+      apiUrl: 'Test apiUrl',
+      merchants: [
+        { id: 'Test id', password: 'Test password', environment: 'Test environment' }
+      ]
+    };
+  })
+};

--- a/test/setup/load-global-mocks.ts
+++ b/test/setup/load-global-mocks.ts
@@ -1,0 +1,41 @@
+// The idea is taken from https://github.com/facebook/jest/issues/335#issuecomment-499025217
+// Without this jest forces you to explicitly load every global mock into your test suite,
+// what is very inconvenient when you need some SUT dependencies to be mocked (a usual case)
+// with a global mock - you don't want to explicitly do anything with such dependencies...
+
+import fs from 'fs';
+import path from 'path';
+
+const rootPath = path.resolve(__dirname, '../../app');
+const globalMocksLocationRoot = path.resolve(__dirname, '../../test/__mocks__');
+
+const isDirectory = (dir: string, file: string) =>
+  fs.statSync(path.join(dir, file)).isDirectory();
+
+const mockPathFor = (dir: string, file: string) => {
+  return path.join(globalMocksLocationRoot, dir.replace(rootPath, ''), file);
+};
+
+const mockExists = (dir: string, file: string) => fs.existsSync(mockPathFor(dir, file));
+
+const mockModule = (dir: string, file: string) => {
+  const realModulePath = path.join(dir, file);
+  const mockPath = mockPathFor(dir, file);
+  console.log(`Mocking ${realModulePath} with ${mockPath}...`);
+  jest.doMock(realModulePath, () => jest.requireActual(mockPath));
+};
+
+const initMocks = (dir: string) => {
+  fs.readdirSync(dir)
+    .forEach((file) => {
+      if (isDirectory(dir, file)) {
+        initMocks(path.join(dir, file));
+      } else if (mockExists(dir, file)) {
+        mockModule(dir, file);
+      }
+    });
+};
+
+// This will check all files below the specified directory.
+console.log(`Looking for global __mocks__ for any files in ${rootPath}/**`);
+initMocks(rootPath);


### PR DESCRIPTION
The essence of the solution:

instead of mocking `config-service` in many test suites (where the original implementation give undesired effects) - 

mock it once for all tests (the mock itself is in `test/__mocks__/domain/services/config-service/index.ts`, it is loaded thankfully to this: [jest.config.js:18](https://github.com/weareplanet/commercetools-planet-integration/pull/14/files#diff-1e058ca1442e46581b13571fb8d261f9e1f5657e26c96634d4c1072f0f0347f1R18)), see more here: https://jestjs.io/docs/manual-mocks#mocking-user-modules

and unmock it [only when the real implementation is needed](https://github.com/weareplanet/commercetools-planet-integration/pull/14/files#diff-d2d92bcfc33f3ebda9318bcdf3dc91a5c102da883dcfd8e16e037f6c484e2c25R5).