### PR TITLE
fix: Remove AWS specificity from abstract handler-interfaces

### DIFF
--- a/app/domain/environment-agnostic-handlers/all-operations-handler/all-operations.integration.spec.ts
+++ b/app/domain/environment-agnostic-handlers/all-operations-handler/all-operations.integration.spec.ts
@@ -68,6 +68,7 @@ describe('Main handler', () => {
       expect(result).toEqual(
         {
           statusCode: HttpStatusCode.OK,
+          body: ''
         }
       );
     });

--- a/app/domain/environment-agnostic-handlers/all-operations-handler/handler.ts
+++ b/app/domain/environment-agnostic-handlers/all-operations-handler/handler.ts
@@ -26,6 +26,7 @@ export default async (req: IAbstractRequest): Promise<IAbstractResponse> => {
     default: {
       return {
         statusCode: HttpStatusCode.OK,
+        body: '',
       };
     }
   }

--- a/app/interfaces/handler-interfaces.ts
+++ b/app/interfaces/handler-interfaces.ts
@@ -1,13 +1,15 @@
-import { APIGatewayProxyResult } from 'aws-lambda';
-
 // Any object in the request body
+
+export type IAbstarctHeaders = Record<string, string>;
+
 export interface IAbstractRequest {
-  body: Record<string, unknown>;
+  headers?: IAbstarctHeaders;
+  body: string | Record<string, unknown>;
 }
 
 export interface IAbstractResponse {
   statusCode: number;
-  body?: Record<string, unknown>;
+  body: string | Record<string, unknown>;
 }
 
 export interface IAbstractRequestHandler {
@@ -21,13 +23,10 @@ export interface IAbstractToEnvHandlerAdapter<IEnvironmentReq, IEnvironmentRes> 
 // Specific object in the request body
 
 export interface IAbstractRequestWithTypedBody<TRequestBody> {
+  headers?: IAbstarctHeaders;
   body: TRequestBody;
 }
 
 export interface IAbstractRequestHandlerWithTypedInput<TRequestBody> {
   (req: IAbstractRequestWithTypedBody<TRequestBody>): Promise<IAbstractResponse>;
-}
-
-export interface IAWSAPIGatewayProxyResult extends Pick<APIGatewayProxyResult, 'statusCode' | 'headers' | 'multiValueHeaders' | 'isBase64Encoded'> {
-  body?: string;
 }


### PR DESCRIPTION
This PR:

- removes AWS specificity from abstract `app/interfaces/handler-interfaces` (such specificity must appear only within `app/environment-specific-handlers/`)
- stops the violation of `APIGatewayProxyResult` shape (body obligation). _At the same time gets rid of an excess weird `IAWSAPIGatewayProxyResult ` type declaration._