### PR TITLE
Fix var setup for both quick/manual deploy modes

### DIFF
--- a/deploy/cloud/aws/aws-deploy.sh
+++ b/deploy/cloud/aws/aws-deploy.sh
@@ -135,9 +135,9 @@ AKSEC=$(aws cloudformation --region ${AWSREGION} describe-stacks --stack-name ${
                     --query "Stacks[0].Outputs[?OutputKey=='SecretKeyforAPIExtensionIAMUserAccessKey'].OutputValue" --output text)
 LAMBDAARN=$(aws lambda get-function --region ${AWSREGION} --function-name ${STACKNAME}-${STACKID} | jq -r .Configuration.FunctionArn)
 echo -e "   ## changing .env file..."
-sed -i "/^CT_API_EXTENSION_AWS_LAMBDA_ACCESS_KEY/c\CT_API_EXTENSION_AWS_LAMBDA_ACCESS_KEY=\"${AKID}\"" ${ENVFILE}
-sed -i "/^CT_API_EXTENSION_AWS_LAMBDA_SECRET/c\CT_API_EXTENSION_AWS_LAMBDA_SECRET=\"${AKSEC}\"" ${ENVFILE}
-sed -i "/^CT_API_EXTENSION_AWS_LAMBDA_ARN/c\CT_API_EXTENSION_AWS_LAMBDA_ARN=\"${LAMBDAARN}\"" ${ENVFILE}
+sed -i "/^export CT_API_EXTENSION_AWS_LAMBDA_ACCESS_KEY/cexport CT_API_EXTENSION_AWS_LAMBDA_ACCESS_KEY=\"${AKID}\"" ${ENVFILE}
+sed -i "/^export CT_API_EXTENSION_AWS_LAMBDA_SECRET/cexport CT_API_EXTENSION_AWS_LAMBDA_SECRET=\"${AKSEC}\"" ${ENVFILE}
+sed -i "/^export CT_API_EXTENSION_AWS_LAMBDA_ARN/cexport CT_API_EXTENSION_AWS_LAMBDA_ARN=\"${LAMBDAARN}\"" ${ENVFILE}
 echo -e "   ## done with this .env file.\n"
 
 echo -e "##### Done"

--- a/deploy/commercetools/api-extension-setup.sh
+++ b/deploy/commercetools/api-extension-setup.sh
@@ -6,8 +6,11 @@
 # 2022-07 - Planet Payments
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ENVFILE="${SCRIPT_DIR}/../env"
 NOW=$(date +%Y-%m-%d_%Hh%Mm%Ss)
 echo -e "\n########## Planet Payment CommerceTools connector - setup API-Extension on CommerceTools, started at ${NOW}."
+
+source ${ENVFILE}
 
 #####
 echo -e "\n##### Checking ENV vars"


### PR DESCRIPTION
Fixes the following issues in the deploy scripts:

* The seds in aws-deploy.sh didn't take the 'export' statements in the
  env file into account.

* api-extension-setup was missing a source to pick up the
  CT_API_EXTENSION_AWS_LAMBDA* vars that are added by the previous step.

Have verified these changes using both the quick and manual deploy
methods.